### PR TITLE
Remove the Metric() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,12 @@ func main() {
 
     param := "something useful here"
 
-    // A metric is an INFO log entry without a payload
-    log.Metric("CUSTOM_METRIC_ENTRY")
-
     // Log a DEBUG message, only visible in when LOG_LEVEL is set to DEBUG
     log.With(logger.Fields{"key": "val", "something": true}).Debug("debug message goes here")
     log.With(logger.Fields{"key": "val"}).Debugf("debug message with %s", param)
 
-    // Log an INFO message
+    // Log an INFO message, should be used for metrics as well
+    log.Info("CUSTOM_METRIC")
     log.With(logger.Fields{"key": "val", "names": []string{"Mauricio", "Manuel"}}).Info("info message goes here")
     log.With(logger.Fields{"key": "val"}).Infof("info message with %s", param)
 

--- a/logger.go
+++ b/logger.go
@@ -184,15 +184,6 @@ func (l Log) Debugf(message string, args ...interface{}) {
 	l.Debug(fmt.Sprintf(message, args...))
 }
 
-// Metric prints out a message with INFO severity and no extra fields
-func (l Log) Metric(message string) {
-	if !isValidLogLevel(INFO) {
-		return
-	}
-
-	l.log(INFO.String(), message)
-}
-
 // Info prints out a message with INFO severity level
 func (l Log) Info(message string) {
 	if !isValidLogLevel(INFO) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -206,21 +206,6 @@ func TestLoggerDebugfWithoutContext(t *testing.T) {
 	}
 }
 
-func TestLoggerMetric(t *testing.T) {
-	initConfig(DEBUG, "robokiller-ivr", "1.0")
-
-	buf := new(bytes.Buffer)
-
-	log := New().SetWriter(buf)
-
-	log.Metric("custom_metric")
-	expected := fmt.Sprintf("{\"severity\":\"INFO\",\"eventTime\":\"%s\",\"message\":\"custom_metric\",\"serviceContext\":{\"service\":\"robokiller-ivr\",\"version\":\"1.0\"}}", time.Now().Format(time.RFC3339))
-	got := strings.TrimRight(buf.String(), "\n")
-	if expected != got {
-		t.Errorf("output %s does not match expected string %s", got, expected)
-	}
-}
-
 func TestLoggerInfo(t *testing.T) {
 	initConfig(DEBUG, "robokiller-ivr", "1.0")
 


### PR DESCRIPTION
This has been discussed among the team in person or via Slack and I finally wanted to put up a PR removing this function.

- `Metric()` is simply a wrapper of `Info()`, both functions have exactly the same effect but the former adds the convenience of removing an extra parameter
- `Metric()` fits our use case for metrics very well, but the goal with the logging library is to create a tool that is useful for anyone working in a Go project on GCP. Metrics can be logged in many different ways using different severity levels, so we shouldn't  try to dictate how people do it and have something in our library that only benefits us
- This PR breaks backwards compatibility but given how young the library is, I guess we can afford to do it at this point before people start using it and it becomes a though decision
- At the time of this writing, the `Metric()` function is only used 21 times throughout our code-base, so this would be an easy refactor