### PR TITLE
Fix append to fields.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -175,21 +175,20 @@ func (l *Log) fields() Fields {
 		f[k] = v
 	}
 	return f
-
 }
 
 // With is used as a chained method to specify which values go in the log entry's context
 func (l *Log) With(fields Fields) *Log {
-
-	for k, v := range l.fields() {
-		fields[k] = v
+	f := l.fields()
+	for k, v := range fields {
+		f[k] = v
 	}
 
 	return &Log{
 		payload: &Payload{
 			ServiceContext: l.payload.ServiceContext,
 			Context: &Context{
-				Data: fields,
+				Data: f,
 			},
 			Stacktrace: "",
 		},

--- a/logger.go
+++ b/logger.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
-	"path/filepath"
 )
 
 type severity int
@@ -157,8 +157,34 @@ func isValidLogLevel(s severity) bool {
 	return s >= logLevel
 }
 
+// fields returns a valid Fields whether or not one exists in the *Log.
+func (l *Log) fields() Fields {
+	f := make(Fields)
+	if l.payload == nil {
+		return f
+	}
+	if l.payload.Context == nil {
+		return f
+	}
+
+	if l.payload.Context.Data == nil {
+		return f
+	}
+
+	for k, v := range l.payload.Context.Data {
+		f[k] = v
+	}
+	return f
+
+}
+
 // With is used as a chained method to specify which values go in the log entry's context
 func (l *Log) With(fields Fields) *Log {
+
+	for k, v := range l.fields() {
+		fields[k] = v
+	}
+
 	return &Log{
 		payload: &Payload{
 			ServiceContext: l.payload.ServiceContext,

--- a/logger_test.go
+++ b/logger_test.go
@@ -30,7 +30,7 @@ func TestLoggerInfoWithOneTimeContext(t *testing.T) {
 	buf.Reset()
 
 	log.With(Fields{"foo": "bar"}).SetWriter(buf).Info("unique INFO message")
-	expected = fmt.Sprintf(`{"severity":"INFO","eventTime":"%s","message":"unique INFO message","serviceContext":{"service":"my-app","version":"1.0"},"context":{"data":{"foo":"bar"}}}`, time.Now().Format(time.RFC3339))
+	expected = fmt.Sprintf(`{"severity":"INFO","eventTime":"%s","message":"unique INFO message","serviceContext":{"service":"my-app","version":"1.0"},"context":{"data":{"foo":"bar","function":"TestLoggerDebug","key":"value"}}}`, time.Now().Format(time.RFC3339))
 	got = strings.TrimRight(buf.String(), "\n")
 	if expected != got {
 		t.Errorf("output file %s does not match expected string %s", got, expected)
@@ -78,14 +78,14 @@ func TestLoggerErrorWithOneTimeContext(t *testing.T) {
 	buf.Reset()
 
 	log.With(Fields{"foo": "bar"}).SetWriter(buf).Error("unique ERROR message")
-	expected = fmt.Sprintf(`{"severity":"ERROR","eventTime":"%s","message":"unique ERROR message","serviceContext":{"service":"my-app","version":"1.0"},"context":{"data":{"foo":"bar"},"reportLocation"`, time.Now().Format(time.RFC3339))
+	expected = fmt.Sprintf(`{"severity":"ERROR","eventTime":"%s","message":"unique ERROR message","serviceContext":{"service":"my-app","version":"1.0"},"context":{"data":{"foo":"bar","function":"TestLoggerError","key":"value"},"reportLocation"`, time.Now().Format(time.RFC3339))
 	got = strings.TrimRight(buf.String(), "\n")
 	if !strings.Contains(got, expected) {
 		t.Errorf("output %s does not contain substring %s", got, expected)
 	}
 
 	// Check that the ERROR entry contains the context
-	if !strings.Contains(got, `"context":{"data":{"foo":"bar"}`) {
+	if !strings.Contains(got, `"context":{"data":{"foo":"bar","function":"TestLoggerError","key":"value"}`) {
 		t.Errorf("output %s does not contain the context", got)
 	}
 


### PR DESCRIPTION
Before, creating a new logger with `With` would overwrite the fields of the "parent" logger. Now it appends to them.

Fixes #17.