### PR TITLE
Fixing issue with old stacktrace that is added to all log payloads

### DIFF
--- a/logger_test.go
+++ b/logger_test.go
@@ -465,3 +465,25 @@ func TestCallerSkip(t *testing.T) {
 		t.Errorf("invalid function name in error log: %s", buf)
 	}
 }
+
+func TestStackTraceIssue(t *testing.T) {
+	initConfig(DEBUG, "stack-trace-issue", "1.0")
+	var (
+		buf = new(bytes.Buffer)
+		log = New().WithOutput(buf)
+		q   = `"stacktrace":"`
+	)
+
+	log.Error("ERROR message")
+	got := buf.String()
+	if !strings.Contains(got, q) {
+		t.Errorf("output should contain %q: %s", q, got)
+	}
+	buf.Reset()
+
+	log.Info("INFO message")
+	got = buf.String()
+	if strings.Contains(got, q) {
+		t.Errorf("output should not contain %q: %s", q, got)
+	}
+}


### PR DESCRIPTION
Once you log an error that stack trace and report location is added to the payload that is attached to the main log and that info is then reported with all log payloads after.

Example:
```json
{
    "severity": "INFO",
    "eventTime": "2021-06-15T10:44:27+02:00",
    "message": "INFO message",
    "serviceContext":
    {
        "service": "stack-trace-issue",
        "version": "1.0"
    },
    "context":
    {
        "reportLocation":
        {
            "filePath": "/src/github.com/teltech/logger/logger_test.go",
            "functionName": "logger.TestStackTraceIssue",
            "lineNumber": 477
        }
    },
    "stacktrace": "goroutine 6 [running]:\ngithub.com/teltech/logger.(*Log).error(0xc00006c420, 0x11758c3, 0x5, 0x1176ef6, 0xd)\n\t/src/github.com/teltech/logger/logger.go:305 +0x7b\ngithub.com/teltech/logger.(*Log).Error(...)\n\t/src/github.com/teltech/logger/logger.go:280\ngithub.com/teltech/logger.TestStackTraceIssue(0xc00012c120)\n\t/src/github.com/teltech/logger/logger_test.go:477 +0x212\ntesting.tRunner(0xc00012c120, 0x1180ec8)\n\t/usr/local/go/src/testing/testing.go:992 +0xdc\ncreated by testing.(*T).Run\n\t/usr/local/go/src/testing/testing.go:1043 +0x357\n"
}
```